### PR TITLE
FEAT:

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ export default function App() {
 
 ### SSR
 
-A simple SSR API is supported. This is an example using Next.js:
+A SSR API is supported. This is an example using Next.js:
 
 ```tsx
 import { useFetcher, FetcherConfig } from "http-react-fetcher";
@@ -584,6 +584,8 @@ function SomeDataFetch() {
 export default function Home({ user }) {
   return (
     <FetcherConfig
+      // You can pass many other configurations to all requests under this tree
+      // like the baseUrl, headers, a resolver, etc
       defaults={{
         "/api/test": {
           user,

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 import * as React from "react";
-import { CustomResponse, FetcherExtendConfig } from "./shared";
+import { CustomResponse } from "./shared";
+declare type FetcherContextType = {
+    headers?: any;
+    baseUrl?: string;
+    body?: object | FormData;
+    defaults?: any;
+    resolver?: (r: Response) => any;
+    children?: any;
+    auto?: boolean;
+    memory?: boolean;
+    refresh?: number;
+};
 declare type FetcherType<FetchDataType, BodyType> = {
     /**
      * url of the resource to fetch
@@ -55,6 +66,10 @@ declare type FetcherType<FetchDataType, BodyType> = {
      * Request configuration
      */
     config?: {
+        /**
+         * Override base url
+         */
+        baseUrl?: string;
         /**
          * Request method
          */
@@ -120,6 +135,10 @@ declare type FetcherConfigOptions<FetchDataType, BodyType = any> = {
      */
     config?: {
         /**
+         * Override base url
+         */
+        baseUrl?: string;
+        /**
          * Request method
          */
         method?: "GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "PURGE" | "LINK" | "UNLINK";
@@ -144,11 +163,7 @@ declare type FetcherConfigOptions<FetchDataType, BodyType = any> = {
  */
 declare const Fetcher: <FetchDataType extends unknown>({ url, default: def, config, children: Children, onError, onResolve, refresh, }: FetcherType<FetchDataType, any>) => JSX.Element | null;
 export default Fetcher;
-declare type fetcherConfigComponentType = {
-    children: any;
-    defaults: any;
-};
-export declare function FetcherConfig({ children, defaults, }: fetcherConfigComponentType): any;
+export declare function FetcherConfig(props: FetcherContextType): JSX.Element;
 /**
  * Fetcher available as a hook
  */
@@ -166,6 +181,10 @@ declare const useFetcher: {
         abort: () => void;
         config: {
             /**
+             * Override base url
+             */
+            baseUrl?: string | undefined;
+            /**
              * Request method
              */
             method?: "GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "PURGE" | "LINK" | "UNLINK" | undefined;
@@ -196,7 +215,7 @@ declare const useFetcher: {
     /**
      * Extend the useFetcher hook
      */
-    extend({ baseUrl, headers, body, resolver, }?: FetcherExtendConfig): {
+    extend(props?: FetcherContextType): {
         <T, BodyType_1 = any>(init: string | FetcherType<T, BodyType_1>, options?: FetcherConfigOptions<T, BodyType_1> | undefined): {
             data: T;
             loading: boolean;
@@ -209,6 +228,10 @@ declare const useFetcher: {
             mutate: React.Dispatch<React.SetStateAction<T>>;
             abort: () => void;
             config: {
+                /**
+                 * Override base url
+                 */
+                baseUrl?: string | undefined;
                 /**
                  * Request method
                  */
@@ -228,9 +251,9 @@ declare const useFetcher: {
             response: CustomResponse<T>;
         };
         config: {
-            baseUrl: string;
-            headers: object | Headers;
-            body: any;
+            baseUrl: any;
+            headers: any;
+            body: object;
         };
         get: import("./shared").RequestWithBody;
         delete: import("./shared").RequestWithBody;
@@ -242,7 +265,7 @@ declare const useFetcher: {
         purge: import("./shared").RequestWithBody;
         link: import("./shared").RequestWithBody;
         unlink: import("./shared").RequestWithBody;
-        Config({ children, defaults, }: fetcherConfigComponentType): any;
+        Config: typeof FetcherConfig;
     };
 };
 export { useFetcher };
@@ -260,6 +283,10 @@ export declare const fetcher: {
         abort: () => void;
         config: {
             /**
+             * Override base url
+             */
+            baseUrl?: string | undefined;
+            /**
              * Request method
              */
             method?: "GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "PURGE" | "LINK" | "UNLINK" | undefined;
@@ -290,7 +317,7 @@ export declare const fetcher: {
     /**
      * Extend the useFetcher hook
      */
-    extend({ baseUrl, headers, body, resolver, }?: FetcherExtendConfig): {
+    extend(props?: FetcherContextType): {
         <T, BodyType_1 = any>(init: string | FetcherType<T, BodyType_1>, options?: FetcherConfigOptions<T, BodyType_1> | undefined): {
             data: T;
             loading: boolean;
@@ -303,6 +330,10 @@ export declare const fetcher: {
             mutate: React.Dispatch<React.SetStateAction<T>>;
             abort: () => void;
             config: {
+                /**
+                 * Override base url
+                 */
+                baseUrl?: string | undefined;
                 /**
                  * Request method
                  */
@@ -322,9 +353,9 @@ export declare const fetcher: {
             response: CustomResponse<T>;
         };
         config: {
-            baseUrl: string;
-            headers: object | Headers;
-            body: any;
+            baseUrl: any;
+            headers: any;
+            body: object;
         };
         get: import("./shared").RequestWithBody;
         delete: import("./shared").RequestWithBody;
@@ -336,7 +367,7 @@ export declare const fetcher: {
         purge: import("./shared").RequestWithBody;
         link: import("./shared").RequestWithBody;
         unlink: import("./shared").RequestWithBody;
-        Config({ children, defaults, }: fetcherConfigComponentType): any;
+        Config: typeof FetcherConfig;
     };
 };
 interface IRequestParam {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react-fetcher",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Data fetching hook for React apps",
   "main": "index.js",
   "scripts": {

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1,4 +1,4 @@
-export declare type CustomResponse<T> = Omit<Response, "json"> & {
+export declare type CustomResponse<T> = Omit<Response, 'json'> & {
     json(): Promise<T>;
 };
 export declare type RequestWithBody = <R = any, BodyType = any>(url: string, reqConfig?: {

--- a/shared/index.js
+++ b/shared/index.js
@@ -63,23 +63,23 @@ function createRequestFn(method, baseUrl, $headers) {
                         _e = c.headers, headers = _e === void 0 ? {} : _e, body = c.body, formatBody = c.formatBody;
                         reqConfig = {
                             method: method,
-                            headers: __assign(__assign({ "Content-Type": "application/json" }, $headers), headers),
+                            headers: __assign(__assign({ 'Content-Type': 'application/json' }, $headers), headers),
                             body: (method === null || method === void 0 ? void 0 : method.match(/(POST|PUT|DELETE|PATCH)/))
-                                ? typeof formatBody === "function"
-                                    ? formatBody((typeof FormData !== "undefined" && body instanceof FormData
+                                ? typeof formatBody === 'function'
+                                    ? formatBody((typeof FormData !== 'undefined' && body instanceof FormData
                                         ? body
                                         : body))
                                     : formatBody === false ||
-                                        (typeof FormData !== "undefined" && body instanceof FormData)
+                                        (typeof FormData !== 'undefined' && body instanceof FormData)
                                         ? body
                                         : JSON.stringify(body)
-                                : undefined,
+                                : undefined
                         };
                         r = undefined;
                         _f.label = 1;
                     case 1:
                         _f.trys.push([1, 4, , 5]);
-                        return [4 /*yield*/, fetch("".concat(baseUrl || "").concat(url), reqConfig)];
+                        return [4 /*yield*/, fetch("".concat(baseUrl || '').concat(url), reqConfig)];
                     case 2:
                         req = _f.sent();
                         r = req;
@@ -93,7 +93,7 @@ function createRequestFn(method, baseUrl, $headers) {
                                     data: def,
                                     error: true,
                                     code: req === null || req === void 0 ? void 0 : req.status,
-                                    config: __assign({ url: "".concat(baseUrl || "").concat(url) }, reqConfig),
+                                    config: __assign({ url: "".concat(baseUrl || '').concat(url) }, reqConfig)
                                 }];
                         }
                         else {
@@ -103,7 +103,7 @@ function createRequestFn(method, baseUrl, $headers) {
                                     data: data,
                                     error: false,
                                     code: req === null || req === void 0 ? void 0 : req.status,
-                                    config: __assign({ url: "".concat(baseUrl || "").concat(url) }, reqConfig),
+                                    config: __assign({ url: "".concat(baseUrl || '').concat(url) }, reqConfig)
                                 }];
                         }
                         return [3 /*break*/, 5];
@@ -115,7 +115,7 @@ function createRequestFn(method, baseUrl, $headers) {
                                 data: def,
                                 error: true,
                                 code: r === null || r === void 0 ? void 0 : r.status,
-                                config: __assign({ url: "".concat(baseUrl || "").concat(url) }, reqConfig),
+                                config: __assign({ url: "".concat(baseUrl || '').concat(url) }, reqConfig)
                             }];
                     case 5: return [2 /*return*/];
                 }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,27 +1,27 @@
-export type CustomResponse<T> = Omit<Response, "json"> & {
-  json(): Promise<T>;
-};
+export type CustomResponse<T> = Omit<Response, 'json'> & {
+  json(): Promise<T>
+}
 
 export type RequestWithBody = <R = any, BodyType = any>(
   url: string,
   reqConfig?: {
-    default?: R;
+    default?: R
     config?: {
-      formatBody?(b: BodyType): any;
-      headers?: any;
-      body?: BodyType;
-    };
-    resolver?: (r: CustomResponse<R>) => any;
-    onError?(error: Error): void;
-    onResolve?(data: R, res: CustomResponse<R>): void;
+      formatBody?(b: BodyType): any
+      headers?: any
+      body?: BodyType
+    }
+    resolver?: (r: CustomResponse<R>) => any
+    onError?(error: Error): void
+    onResolve?(data: R, res: CustomResponse<R>): void
   }
 ) => Promise<{
-  error: any;
-  data: R;
-  config: any;
-  code: number;
-  res: CustomResponse<R>;
-}>;
+  error: any
+  data: R
+  config: any
+  code: number
+  res: CustomResponse<R>
+}>
 
 /**
  * Creates a new request function. This is for usage with fetcher and fetcher.extend
@@ -37,90 +37,90 @@ export function createRequestFn(
       resolver = (e) => e.json(),
       config: c = {},
       onResolve = () => {},
-      onError = () => {},
-    } = init;
+      onError = () => {}
+    } = init
 
-    const { headers = {}, body, formatBody } = c;
+    const { headers = {}, body, formatBody } = c
 
     const reqConfig = {
       method,
       headers: {
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         ...$headers,
-        ...headers,
+        ...headers
       },
       body: method?.match(/(POST|PUT|DELETE|PATCH)/)
-        ? typeof formatBody === "function"
+        ? typeof formatBody === 'function'
           ? formatBody(
-              (typeof FormData !== "undefined" && body instanceof FormData
+              (typeof FormData !== 'undefined' && body instanceof FormData
                 ? body
                 : body) as any
             )
           : formatBody === false ||
-            (typeof FormData !== "undefined" && body instanceof FormData)
+            (typeof FormData !== 'undefined' && body instanceof FormData)
           ? body
           : JSON.stringify(body)
-        : undefined,
-    };
+        : undefined
+    }
 
-    let r = undefined as any;
+    let r = undefined as any
     try {
-      const req = await fetch(`${baseUrl || ""}${url}`, reqConfig);
-      r = req;
-      const data = await resolver(req);
+      const req = await fetch(`${baseUrl || ''}${url}`, reqConfig)
+      r = req
+      const data = await resolver(req)
       if (req?.status >= 400) {
-        onError(true as any);
+        onError(true as any)
         return {
           res: req,
           data: def,
           error: true,
           code: req?.status,
-          config: { url: `${baseUrl || ""}${url}`, ...reqConfig },
-        };
+          config: { url: `${baseUrl || ''}${url}`, ...reqConfig }
+        }
       } else {
-        onResolve(data, req);
+        onResolve(data, req)
         return {
           res: req,
           data: data,
           error: false,
           code: req?.status,
-          config: { url: `${baseUrl || ""}${url}`, ...reqConfig },
-        };
+          config: { url: `${baseUrl || ''}${url}`, ...reqConfig }
+        }
       }
     } catch (err) {
-      onError(err);
+      onError(err)
       return {
         res: r,
         data: def,
         error: true,
         code: r?.status,
-        config: { url: `${baseUrl || ""}${url}`, ...reqConfig },
-      };
+        config: { url: `${baseUrl || ''}${url}`, ...reqConfig }
+      }
     }
-  } as RequestWithBody;
+  } as RequestWithBody
 }
 
 export type FetcherExtendConfig = {
   /**
    * Request base url
    */
-  baseUrl?: string;
+  baseUrl?: string
   /**
    * Headers to include in each request
    */
-  headers?: Headers | object;
+  headers?: Headers | object
   /**
    * Body to include in each request (if aplicable)
    */
-  body?: any;
+  body?: any
   /**
    * Customize how body is formated for the next requests. By default it will be sent in JSON format but you can set it to false if for example, you are sending a `FormData`
    * body, or to `b => JSON.stringify(b)` for example, if you want to send JSON data
    * (the last one is the default behaviour so in that case you can ignore it)
    */
-  formatBody?: (b: any) => any;
+  formatBody?: (b: any) => any
   /**
    * Custom resolver
    */
-  resolver?: (d: Response) => any;
-};
+  resolver?: (d: Response) => any
+}

--- a/test/json/config.test.ts
+++ b/test/json/config.test.ts
@@ -1,0 +1,38 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { FetcherConfig, useFetcher } from "../../";
+import mocks from "../mocks";
+
+test("Config is modified by AtomicState provider", async () => {
+  global.fetch = jest.fn().mockImplementation((url, config) =>
+    Promise.resolve({
+      json: () => mocks[config.method],
+    })
+  );
+
+  let r: any;
+
+  await act(async () => {
+    const { result } = renderHook(() =>
+      useFetcher({
+        url: "",
+        default: [],
+        config: {
+          baseUrl: "test-url",
+          method: "DELETE",
+          body: {
+            careers: [
+              "Backend Developer",
+              "Cloud Enginner",
+              "DB Administrator",
+            ],
+          },
+        },
+      })
+    );
+
+    r = result;
+  });
+  await waitFor(async () => {
+    expect(r.current.config.baseUrl).toBe("test-url");
+  });
+});


### PR DESCRIPTION
Adds more configuration accesibility in the `FetcherConfig` and `Config` of `fetcher.extend`, these include:
  - `baseUrl`
  - `headers`
  - `refresh`
  - `resolver`
  - `defaults`
  
Example:

```jsx
import { fetcher } from 'fetcher'

const useRequest = fetcher.extend({
  baseUrl: 'https://jsonplaceholder.typicode.com',
  headers: {
    auth: 'token'
  }
})

function ExampleFetch() {
  const { data, config } = useRequest('/todos/10')
  return <pre>{JSON.stringify({ config, data }, null, 2)}</pre>
}
export default function App() {
  return (
    <div>
      <useRequest.Config
        // Although we specified a baseUrl in fetcher.Config, this will overwrite it
        // However, if the baseUrl is specified in the request .config
        // that will overwrite both the baseUrl in fetcher.extend
        // and the one used when calling <useRequest.Config> or <FetcherConfig>
        baseUrl='https://jsonplaceholder.typicode.com'
        headers={{
          a: 'b'
        }}
        // We set default values for our requests. We skip the portion that is already in the baseUrl
        defaults={{
          '/todos/10': {
            userId: 1,
            id: 10,
            title: 'illo est ratione doloremque quia maiores aut',
            completed: true
          }
        }}
      >
        <ExampleFetch />
      </useRequest.Config>

      {/* This will not receive the url that we use in useRequest.Config, it will
          use the one passed when calling fetcher.extend()
      */}
      <ExampleFetch />
    </div>
  )
}

```