### PR TITLE
feats:

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn add http-react-fetcher
 Without React
 
 ```html
-<script src="https://unpkg.com/http-react-fetcher@1.8.2/dist/vanilla.min.js"></script>
+<script src="https://unpkg.com/http-react-fetcher@1.8.3/dist/vanilla.min.js"></script>
 ```
 
 #### Basic usage

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,13 @@ declare type FetcherContextType = {
     headers?: any;
     baseUrl?: string;
     body?: object | FormData;
-    defaults?: any;
+    defaults?: {
+        [key: string]: {
+            id?: any;
+            value?: any;
+            config?: any;
+        };
+    };
     resolver?: (r: Response) => any;
     children?: any;
     auto?: boolean;
@@ -63,7 +69,7 @@ declare type FetcherType<FetchDataType, BodyType> = {
     /**
      * url of the resource to fetch
      */
-    url: string;
+    url?: string;
     /**
      * Default data value
      */
@@ -282,7 +288,19 @@ export declare function mutateData(...pairs: [any, any | ((cache: any) => any), 
  */
 export declare function useFetcherConfig(): FetcherContextType;
 /**
- * Fetcher available as a hook
+ * Get the data state of a request using its id
+ */
+export declare function useFetcherData<T = any>(id: any): T;
+/**
+ * Get the loading state of a request using its id
+ */
+export declare function useFetcherLoading(id: any): boolean;
+/**
+ * Get the error state of a request using its id
+ */
+export declare function useFetcherError(id: any): Error | null;
+/**
+ * Fetcher hook
  */
 declare const useFetcher: {
     <FetchDataType extends unknown, BodyType = any>(init: string | FetcherType<FetchDataType, BodyType>, options?: FetcherConfigOptions<FetchDataType, BodyType> | undefined): {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react-fetcher",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Data fetching for React",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Fixes and feats:
- Fixed SSR when using the `FetcherConfig` component
- Added `useFetcherData`, `useFetcherLoading` and `useFetcherError` hooks that return their respective values using a request id passed when calling `useFetcher`

Example:

```tsx
import { useFetcher, useFetcherLoading } from 'http-react-fetcher'

function SomeData(){
  const { data } = useFetcher('/some-data', {
    id: 'my-data' // It can be anything that can be serialized as JSON
  })
}


// Reading the loading state and subscribing to its changes
function LoadingStatus(){
  const isLoading = useFetcherLoading('my-data')
  
  return <span>{isLoading ? 'Loading data' : 'Data loaded'}</span>
}

// Reading the error state and subscribing to its changes
function LoadingStatus(){
  const hasError= useFetcherError('my-data')
  
  return <span>{hasError? 'Failed to load' : 'ok'}</span>
}



// You can always read everything
function Statuses(){
  const { data, loading, error } = useFetcher({
    id: 'my-data' // Because both useFetcher calls use the same id, this call won't make another request
  })
}
```

### Breaking changes:
- When using `FetcherConfig` and setting the `defaults` prop, instead of directly setting a value like this

```tsx
<FetcherConfig
  defaults={{
    '/some-data': {
      a: 'b'
    }
  }}
>
  {children}
</FetcherConfig>
```
You should set a `value`  and optional `id` properties:

```tsx
<FetcherConfig
  defaults={{
    '/some-url': {
      id: 'my-data',
      value: {
        a: 'b'
      }
    }
  }}
>
  {children}
</FetcherConfig>
```

You should always use an `id` to make sure that even identical urls are independent from each other when needed