### PR TITLE
fix(revalidation):

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn add http-react-fetcher
 Without React
 
 ```html
-<script src="https://unpkg.com/http-react-fetcher@1.8.3/dist/vanilla.min.js"></script>
+<script src="https://unpkg.com/http-react-fetcher@1.8.4/dist/vanilla.min.js"></script>
 ```
 
 #### Basic usage

--- a/index.js
+++ b/index.js
@@ -721,12 +721,16 @@ var useFetcher = function (init, options) {
                         setLoading(true);
                         setError(null);
                         if (!runningRequests[resolvedKey]) {
-                            requestEmitter.emit(resolvedKey, {
-                                requestCallId: requestCallId,
-                                loading: true,
-                                error: null,
-                            });
-                            fetchData();
+                            // We are preventing revalidation where we only need updates about
+                            // 'loading', 'error' and 'data' because the url can be ommited.
+                            if (url !== "") {
+                                requestEmitter.emit(resolvedKey, {
+                                    requestCallId: requestCallId,
+                                    loading: true,
+                                    error: null,
+                                });
+                                fetchData();
+                            }
                         }
                     }
                     return [2 /*return*/];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react-fetcher",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Data fetching for React",
   "main": "index.js",
   "scripts": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1091,12 +1091,16 @@ const useFetcher = <FetchDataType extends unknown, BodyType = any>(
         setLoading(true);
         setError(null);
         if (!runningRequests[resolvedKey]) {
-          requestEmitter.emit(resolvedKey, {
-            requestCallId,
-            loading: true,
-            error: null,
-          });
-          fetchData();
+          // We are preventing revalidation where we only need updates about
+          // 'loading', 'error' and 'data' because the url can be ommited.
+          if (url !== "") {
+            requestEmitter.emit(resolvedKey, {
+              requestCallId,
+              loading: true,
+              error: null,
+            });
+            fetchData();
+          }
         }
       }
     }


### PR DESCRIPTION
Only revalidates if `url` property is present to prevent revalidation in other hooks that are not supposed to revalidate