### PR TITLE
Feat defaults and auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn add http-react-fetcher
 Without React
 
 ```html
-<script src="https://unpkg.com/http-react-fetcher@1.8.7/dist/vanilla.min.js"></script>
+<script src="https://unpkg.com/http-react-fetcher@1.8.8/dist/vanilla.min.js"></script>
 ```
 
 #### Basic usage

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn add http-react-fetcher
 Without React
 
 ```html
-<script src="https://unpkg.com/http-react-fetcher@1.8.6/dist/vanilla.min.js"></script>
+<script src="https://unpkg.com/http-react-fetcher@1.8.7/dist/vanilla.min.js"></script>
 ```
 
 #### Basic usage

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,9 +36,18 @@ declare type FetcherContextType = {
     headers?: any;
     baseUrl?: string;
     body?: object | FormData;
+    /**
+     * Keys in `defaults` are just friendly names. Defaults are based on the `id` and `value` passed
+     */
     defaults?: {
         [key: string]: {
+            /**
+             * The `id` passed to the request
+             */
             id?: any;
+            /**
+             * Default value for this request
+             */
             value?: any;
             config?: any;
         };
@@ -345,6 +354,10 @@ export declare function useFetcherId<ResponseType = any, BodyType = any>(id: any
     id: any;
     key: string;
 };
+/**
+ * Create a configuration object to use in a 'useFetcher'call
+ */
+export declare type FetcherInit<FDT = any, BT = any> = FetcherConfigOptions<FDT, BT>;
 /**
  * Fetcher hook
  */

--- a/index.d.ts
+++ b/index.d.ts
@@ -357,7 +357,9 @@ export declare function useFetcherId<ResponseType = any, BodyType = any>(id: any
 /**
  * Create a configuration object to use in a 'useFetcher'call
  */
-export declare type FetcherInit<FDT = any, BT = any> = FetcherConfigOptions<FDT, BT>;
+export declare type FetcherInit<FDT = any, BT = any> = FetcherConfigOptions<FDT, BT> & {
+    url?: string;
+};
 /**
  * Fetcher hook
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react-fetcher",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Data fetching for React",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react-fetcher",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Data fetching for React",
   "main": "index.js",
   "scripts": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -627,7 +627,9 @@ export function useFetcherId<ResponseType = any, BodyType = any>(id: any) {
 /**
  * Create a configuration object to use in a 'useFetcher'call
  */
-export type FetcherInit<FDT = any, BT = any> = FetcherConfigOptions<FDT, BT>;
+export type FetcherInit<FDT = any, BT = any> = FetcherConfigOptions<FDT, BT> & {
+  url?: string;
+};
 
 /**
  * Fetcher hook


### PR DESCRIPTION
- Added `FetcherInit` type

Usage:

```tsx
import type { FetcherInit } from 'http-react-fetcher'

const myFetcher: FetcherInit<MyDataType> = {
  url: '/api/user',
  id: 'user-info'
}

function ShowInfo(){
  const { data } = useFetcher(myFetcher)

  return <pre>{JSON.stringify(data, null, 2)}</pre>
}

// This request is deduplicated :D
const ShowLoading(){
  const { loading } = useFetcher(myFetcher)
  
  return <p>{loading? "Loading" : "Ready"}</p>
}
```

- Fixed bug in requests when setting `auto` to `false`
- The default value is passed between `useFetcher` calls that share the same `id`
- When setting `auto` to false, `loading` should be `false` by default