### PR TITLE
fixes and feats:

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ yarn add http-react-fetcher
 With React
 
 ```html
-<script src="https://unpkg.com/http-react-fetcher@1.9.7/dist/http-react-fetcher.min.js"></script>
+<script src="https://unpkg.com/http-react-fetcher@2.0.7/dist/http-react-fetcher.min.js"></script>
 ```
 
 
 Without React
 
 ```html
-<script src="https://unpkg.com/http-react-fetcher@2.0.5/dist/vanilla.min.js"></script>
+<script src="https://unpkg.com/http-react-fetcher@2.0.7/dist/vanilla.min.js"></script>
 ```
 
 [Getting started](https://fetcher.atomic-state.org/docs/intro)

--- a/index.d.ts
+++ b/index.d.ts
@@ -935,7 +935,101 @@ declare function useUNLINK<FetchDataType = any, BodyType = any>(init: FetcherTyp
     id: any;
     key: string;
 };
-export { useFetcher as useFetch, useFetcherLoading as useLoading, useFetcherConfig as useConfig, useFetcherData as useData, useFetcherCode as useCode, useFetcherError as useError, useFetcherMutate as useMutate, useFetcherId as useFetchId, useGET, useDELETE, useHEAD, useOPTIONS, usePOST, usePUT, usePATCH, usePURGE, useLINK, useUNLINK };
+/**
+ * Get a blob of the response. You can pass an `objectURL` property that will convet that blob into a string using `URL.createObjectURL`
+ */
+export declare function useFetcherBlob<FetchDataType = string, BodyType = any>(init: (FetcherType<FetchDataType, BodyType> & {
+    objectURL?: boolean;
+}) | string, options?: FetcherConfigOptions<FetchDataType, BodyType> & {
+    objectURL?: boolean;
+}): {
+    data: FetchDataType;
+    loading: boolean;
+    error: Error | null;
+    online: boolean;
+    code: number;
+    reFetch: () => Promise<void>;
+    mutate: (update: FetchDataType | ((prev: FetchDataType) => FetchDataType), callback?: ((data: FetchDataType, fetcher: ImperativeFetcher) => void) | undefined) => FetchDataType;
+    fetcher: ImperativeFetcher;
+    abort: () => void;
+    config: {
+        /**
+         * Override base url
+         */
+        baseUrl?: string | undefined;
+        /**
+         * Request method
+         */
+        method?: "GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "PURGE" | "LINK" | "UNLINK" | undefined;
+        headers?: object | Headers | undefined;
+        query?: any;
+        /**
+         * URL params
+         */
+        params?: any;
+        body?: BodyType | undefined;
+        /**
+         * Customize how body is formated for the request. By default it will be sent in JSON format
+         * but you can set it to false if for example, you are sending a `FormData`
+         * body, or to `b => JSON.stringify(b)` for example, if you want to send JSON data
+         * (the last one is the default behaviour so in that case you can ignore it)
+         */
+        formatBody?: boolean | ((b: BodyType) => any) | undefined;
+    } & {
+        baseUrl: string;
+        url: string;
+        rawUrl: string;
+    };
+    response: CustomResponse<FetchDataType>;
+    id: any;
+    key: string;
+};
+/**
+ * Get a text of the response
+ */
+export declare function useFetcherText<FetchDataType = string, BodyType = any>(init: FetcherType<string, BodyType> | string, options?: FetcherConfigOptions<string, BodyType>): {
+    data: string;
+    loading: boolean;
+    error: Error | null;
+    online: boolean;
+    code: number;
+    reFetch: () => Promise<void>;
+    mutate: (update: string | ((prev: string) => string), callback?: ((data: string, fetcher: ImperativeFetcher) => void) | undefined) => string;
+    fetcher: ImperativeFetcher;
+    abort: () => void;
+    config: {
+        /**
+         * Override base url
+         */
+        baseUrl?: string | undefined;
+        /**
+         * Request method
+         */
+        method?: "GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "PURGE" | "LINK" | "UNLINK" | undefined;
+        headers?: object | Headers | undefined;
+        query?: any;
+        /**
+         * URL params
+         */
+        params?: any;
+        body?: BodyType | undefined;
+        /**
+         * Customize how body is formated for the request. By default it will be sent in JSON format
+         * but you can set it to false if for example, you are sending a `FormData`
+         * body, or to `b => JSON.stringify(b)` for example, if you want to send JSON data
+         * (the last one is the default behaviour so in that case you can ignore it)
+         */
+        formatBody?: boolean | ((b: BodyType) => any) | undefined;
+    } & {
+        baseUrl: string;
+        url: string;
+        rawUrl: string;
+    };
+    response: CustomResponse<string>;
+    id: any;
+    key: string;
+};
+export { useFetcher as useFetch, useFetcherLoading as useLoading, useFetcherConfig as useConfig, useFetcherData as useData, useFetcherCode as useCode, useFetcherError as useError, useFetcherMutate as useMutate, useFetcherId as useFetchId, useFetcherBlob as useBlob, useFetcherText as useText, useGET, useDELETE, useHEAD, useOPTIONS, usePOST, usePUT, usePATCH, usePURGE, useLINK, useUNLINK };
 /**
  * Create a configuration object to use in a 'useFetcher' call
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react-fetcher",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "React hooks for data fetching",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Fixed small `onResolve` and `mutateData` bugs


- Added two hooks: `useBlob` and `useText`. `useBlob` returns the blob version of the response and can return an object url blob by passing `objectURL: true`, and `useText` returns the text version of the response

Example: 
```jsx
import { useFetcherBlob } from 'http-react-fetcher' // You can also import 'useBlob' which is the same

function FetchImage() {
  const { data } = useFetcherBlob(
    'https://rickandmortyapi.com/api/character/avatar/284.jpeg',
    {
      objectURL: true,
    }
  )

  return <img src={data} alt='' />
}
```