### PR TITLE
fixes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ With React
 Without React
 
 ```html
-<script src="https://unpkg.com/http-react-fetcher@2.0.8/dist/vanilla.min.js"></script>
+<script src="https://unpkg.com/http-react-fetcher@2.0.9/dist/vanilla.min.js"></script>
 ```
 
 [Getting started](https://fetcher.atomic-state.org/docs/intro)

--- a/index.d.ts
+++ b/index.d.ts
@@ -161,11 +161,16 @@ declare type FetcherType<FetchDataType, BodyType> = {
     /**
      * Function to run when props change
      */
-    onPropsChange?: (revalidate: () => void, 
-    /**
-     * An imperative version of `useFetcher`
-     */
-    fetcher: ImperativeFetcher) => void;
+    onPropsChange?: (rev: {
+        revalidate: () => void;
+        cancel: {
+            (reason?: any): void;
+            (): void;
+        };
+        fetcher: ImperativeFetcher;
+        props: FetcherConfigOptions<FetchDataType, BodyType>;
+        previousProps: FetcherConfigOptions<FetchDataType, BodyType>;
+    }) => void;
     /**
      * Function to run when the request fails
      */
@@ -175,8 +180,6 @@ declare type FetcherType<FetchDataType, BodyType> = {
      */
     onAbort?: () => void;
     /**
-     * @deprecated - Use the `abort` function to cancel a request instead
-     *
      * Whether a change in deps will cancel a queued request and make a new one
      */
     cancelOnChange?: boolean;
@@ -282,11 +285,16 @@ declare type FetcherConfigOptions<FetchDataType, BodyType = any> = {
     /**
      * Function to run when props change
      */
-    onPropsChange?: (revalidate: () => void, 
-    /**
-     * An imperative version of `useFetcher`
-     */
-    fetcher: ImperativeFetcher) => void;
+    onPropsChange?: (rev: {
+        revalidate: () => void;
+        cancel: {
+            (reason?: any): void;
+            (): void;
+        };
+        fetcher: ImperativeFetcher;
+        props: FetcherConfigOptions<FetchDataType, BodyType>;
+        previousProps: FetcherConfigOptions<FetchDataType, BodyType>;
+    }) => void;
     /**
      * Function to run when the request fails
      */
@@ -296,8 +304,6 @@ declare type FetcherConfigOptions<FetchDataType, BodyType = any> = {
      */
     onAbort?: () => void;
     /**
-     * @deprecated Use the `abort` function to cancel a request instead
-     *
      * Whether a change in deps will cancel a queued request and make a new one
      */
     cancelOnChange?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react-fetcher",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "React hooks for data fetching",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Fixed `cancelOnChange` to make it more stable
- `onPropsChange` gives access to `cancel`, `revalidate`, `fetcher`, `previousProps` and `props`

Example:

```tsx
import { useFetch } from 'http-react-fetcher'

function RecordSearch({ recordId }) {
  const { data } = useFetch('/records/:id', {
    id: 'record-search', // just a friendly id
    config: {
      params: {
        id: recordId 
      },
    },
    onPropsChange({ cancel, previousProps, props }) {
      console.log('Previous record id:', previousProps.config?.params.id)

      // If the request should be cancelled when props change
      // to make a new request with the latest props.
      // This works the same as when setting 'cancelOnChange' to true
      cancel()

      console.log('New record id:', props.config?.params.id)
    },
  })

  // your component
}
```