### PR TITLE
feat(graphql):

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ With React
 Without React
 
 ```html
-<script src="https://unpkg.com/http-react-fetcher@2.2.5/dist/vanilla.min.js"></script>
+<script src="https://unpkg.com/http-react-fetcher@2.2.6/dist/vanilla.min.js"></script>
 ```
 
 [Getting started](https://fetcher.atomic-state.org/docs/intro)

--- a/dist/http-react-fetcher.js
+++ b/dist/http-react-fetcher.js
@@ -732,6 +732,18 @@
     }
     return returnObj
   }
+
+  /**
+   *
+   * @param queries
+   * @returns A hook that has full TypeScript support and offers autocomplete for every query passed
+   */
+  function queryProvider(queries) {
+    return function useQuery(queryName, otherConfig) {
+      return useGql(queries[queryName], otherConfig)
+    }
+  }
+
   /**
    * Make a graphQL request
    */
@@ -2048,6 +2060,7 @@
   }
 
   window.useGql = useGql
+  window.queryProvider = queryProvider
   window.gql = gql
   window.FetcherConfig = FetcherConfig
   window.fetcher = fetcher

--- a/index.d.ts
+++ b/index.d.ts
@@ -940,6 +940,100 @@ export declare function gql<T = any, VT = {
     $$vars: VT;
 };
 /**
+ *
+ * @param queries
+ * @returns A hook that has full TypeScript support and offers autocomplete for every query passed
+ */
+export declare function queryProvider<R>(queries: {
+    [e in keyof R]: {
+        $$query: R[e];
+        $$vars: {
+            [k: string]: any;
+        };
+    };
+}): <T = Exclude<keyof R, string>>(queryName: keyof typeof queries, otherConfig?: Omit<FetcherInit<T | { [e in keyof R]: {
+    $$query: R[e];
+    $$vars: {
+        [k: string]: any;
+    };
+}; }[keyof R]["$$query"], any>, "url"> | undefined) => {
+    data: T | { [e in keyof R]: {
+        $$query: R[e];
+        $$vars: {
+            [k: string]: any;
+        };
+    }; }[keyof R]["$$query"];
+    loading: boolean;
+    error: Error | null;
+    online: boolean;
+    code: number;
+    reFetch: () => Promise<void>;
+    mutate: (update: T | { [e in keyof R]: {
+        $$query: R[e];
+        $$vars: {
+            [k: string]: any;
+        };
+    }; }[keyof R]["$$query"] | ((prev: T | { [e in keyof R]: {
+        $$query: R[e];
+        $$vars: {
+            [k: string]: any;
+        };
+    }; }[keyof R]["$$query"]) => T | { [e in keyof R]: {
+        $$query: R[e];
+        $$vars: {
+            [k: string]: any;
+        };
+    }; }[keyof R]["$$query"]), callback?: ((data: T | { [e in keyof R]: {
+        $$query: R[e];
+        $$vars: {
+            [k: string]: any;
+        };
+    }; }[keyof R]["$$query"], fetcher: ImperativeFetcher) => void) | undefined) => T | { [e in keyof R]: {
+        $$query: R[e];
+        $$vars: {
+            [k: string]: any;
+        };
+    }; }[keyof R]["$$query"];
+    fetcher: ImperativeFetcher;
+    abort: () => void;
+    config: {
+        /**
+         * Override base url
+         */
+        baseUrl?: string | undefined;
+        /**
+         * Request method
+         */
+        method?: "GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "PURGE" | "LINK" | "UNLINK" | undefined;
+        headers?: object | Headers | undefined;
+        query?: any;
+        /**
+         * URL params
+         */
+        params?: any;
+        body?: any;
+        /**
+         * Customize how body is formated for the request. By default it will be sent in JSON format
+         * but you can set it to false if for example, you are sending a `FormData`
+         * body, or to `b => JSON.stringify(b)` for example, if you want to send JSON data
+         * (the last one is the default behaviour so in that case you can ignore it)
+         */
+        formatBody?: boolean | ((b: any) => any) | undefined;
+    } & {
+        baseUrl: string;
+        url: string;
+        rawUrl: string;
+    };
+    response: CustomResponse<T | { [e in keyof R]: {
+        $$query: R[e];
+        $$vars: {
+            [k: string]: any;
+        };
+    }; }[keyof R]["$$query"]>;
+    id: any;
+    key: string;
+};
+/**
  * Make a graphQL request
  */
 export declare function useGql<T = any, VT = {

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.createHttpClient = exports.isFormData = exports.fetcher = exports.useFetcher = exports.useImperative = exports.useUNLINK = exports.useLINK = exports.usePURGE = exports.usePATCH = exports.usePUT = exports.usePOST = exports.useOPTIONS = exports.useHEAD = exports.useDELETE = exports.useGET = exports.useText = exports.useBlob = exports.useFetchId = exports.useMutate = exports.useError = exports.useCode = exports.useData = exports.useConfig = exports.useLoading = exports.useFetch = exports.useGql = exports.gql = exports.useFetcherText = exports.useFetcherBlob = exports.useResolve = exports.useFetcherId = exports.useFetcherMutate = exports.useFetcherError = exports.useFetcherLoading = exports.useFetcherCode = exports.useFetcherData = exports.useFetcherConfig = exports.mutateData = exports.revalidate = exports.FetcherConfig = exports.setURLParams = void 0;
+exports.createHttpClient = exports.isFormData = exports.fetcher = exports.useFetcher = exports.useImperative = exports.useUNLINK = exports.useLINK = exports.usePURGE = exports.usePATCH = exports.usePUT = exports.usePOST = exports.useOPTIONS = exports.useHEAD = exports.useDELETE = exports.useGET = exports.useText = exports.useBlob = exports.useFetchId = exports.useMutate = exports.useError = exports.useCode = exports.useData = exports.useConfig = exports.useLoading = exports.useFetch = exports.useGql = exports.queryProvider = exports.gql = exports.useFetcherText = exports.useFetcherBlob = exports.useResolve = exports.useFetcherId = exports.useFetcherMutate = exports.useFetcherError = exports.useFetcherLoading = exports.useFetcherCode = exports.useFetcherData = exports.useFetcherConfig = exports.mutateData = exports.revalidate = exports.FetcherConfig = exports.setURLParams = void 0;
 var React = require("react");
 var react_1 = require("react");
 var events_1 = require("events");
@@ -651,6 +651,17 @@ function gql() {
     return returnObj;
 }
 exports.gql = gql;
+/**
+ *
+ * @param queries
+ * @returns A hook that has full TypeScript support and offers autocomplete for every query passed
+ */
+function queryProvider(queries) {
+    return function useQuery(queryName, otherConfig) {
+        return useGql(queries[queryName], otherConfig);
+    };
+}
+exports.queryProvider = queryProvider;
 /**
  * Make a graphQL request
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react-fetcher",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "React hooks for data fetching",
   "main": "index.js",
   "scripts": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1032,6 +1032,33 @@ export function gql<T = any, VT = { [k: string]: any }>(...args: any) {
 }
 
 /**
+ *
+ * @param queries
+ * @returns A hook that has full TypeScript support and offers autocomplete for every query passed
+ */
+export function queryProvider<R>(queries: {
+  [e in keyof R]: {
+    $$query: R[e]
+    $$vars: {
+      [k: string]: any
+    }
+  }
+}) {
+  return function useQuery<T = keyof Omit<R, string>>(
+    queryName: keyof typeof queries,
+    otherConfig?: Omit<
+      FetcherInit<typeof queries[keyof typeof queries]['$$query'] | T>,
+      'url'
+    >
+  ) {
+    return useGql<typeof queries[keyof typeof queries]['$$query'] | T>(
+      queries[queryName],
+      otherConfig
+    )
+  }
+}
+
+/**
  * Make a graphQL request
  */
 export function useGql<T = any, VT = { [k: string]: any }>(


### PR DESCRIPTION
## Feat: `queryProvider`
Added `queryProvider` function that accepts a dictionary with queries created with the `gql` function and returns a hook that is fully typed (using the static typing of the created queries).

Example:

```tsx
import { gql, queryProvider } from 'http-react-fetcher'

/**
 * The characters result type
 */
export type CharactersResultType = {
  data: {
    characters: {
      results: {
        name: string
        status: string
        location: {
          name: string
        }
      }[]
    }
  }
}

// We add the type above to our characters' query
const charactersQuery = gql<CharactersResultType>`
  query {
    characters {
      results {
        name
        status
        location {
          name
        }
      }
    }
  }
`

// We create a dictionary with all our queries
const queries = {
  charactersQuery
}

// We create a hook that we can use across our app without the need to import a single query
// This also inherits all the config passed in the 'FetcherConfig' component and can be overwritten with the second argument.
const useQuery = queryProvider(queries)

export default function App() {
  // This is fully typed
  const { data } = useQuery('charactersQuery', {
    onResolve(data) {
      console.log(data)
    }
  })

  return (
    <div>
      <pre>{JSON.stringify(data, null, 2)}</pre>
    </div>
  )
}

```